### PR TITLE
feat: polish SaaS-inspired UI

### DIFF
--- a/App.scss
+++ b/App.scss
@@ -4,6 +4,11 @@
   font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  --gradient-start: #eef2ff;
+  --gradient-end: #fdf2f8;
+  --card-glow: 0 30px 60px rgba(79, 70, 229, 0.12);
+  --border: rgba(148, 163, 184, 0.2);
+  --glass: rgba(255, 255, 255, 0.85);
 }
 
 * {
@@ -26,6 +31,36 @@ body {
   display: flex;
   flex-direction: column;
   background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  position: relative;
+}
+
+.app__background {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.app__orb {
+  position: absolute;
+  width: 480px;
+  height: 480px;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.35;
+}
+
+.app__orb--left {
+  background: #a855f7;
+  top: -120px;
+  left: -120px;
+}
+
+.app__orb--right {
+  background: #38bdf8;
+  bottom: -180px;
+  right: -180px;
 }
 
 .app--loading {
@@ -96,11 +131,33 @@ body {
   box-shadow: 0 8px 20px rgba(249, 115, 22, 0.2);
 }
 
+.brand__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.brand__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 10px;
+  font-weight: 900;
+  color: #a855f7;
+}
+
 .brand__title {
   margin: 0;
   font-size: 20px;
   font-weight: 800;
   letter-spacing: -0.02em;
+}
+
+.brand__subtitle {
+  margin: 0;
+  font-size: 12px;
+  color: #475569;
+  font-weight: 600;
 }
 
 .mode-toggle {
@@ -110,10 +167,11 @@ body {
 
 .mode-toggle__inner {
   display: inline-flex;
-  background: #f1f5f9;
+  background: rgba(255, 255, 255, 0.9);
   padding: 4px;
   border-radius: 14px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 10px 30px rgba(99, 102, 241, 0.12);
+  border: 1px solid var(--border);
 }
 
 .mode-toggle__button {
@@ -133,9 +191,17 @@ body {
 }
 
 .mode-toggle__button.is-active {
-  background: #ffffff;
-  color: #2563eb;
-  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.08);
+  background: linear-gradient(135deg, #6366f1, #7c3aed);
+  color: #ffffff;
+  box-shadow: 0 10px 22px rgba(99, 102, 241, 0.24);
+}
+
+.mode-toggle__helper {
+  margin: 6px 0 0;
+  text-align: center;
+  font-size: 12px;
+  color: #475569;
+  font-weight: 600;
 }
 
 .header-actions {
@@ -143,6 +209,11 @@ body {
   align-items: center;
   justify-content: flex-end;
   gap: 16px;
+}
+
+.header-actions__meta {
+  display: flex;
+  gap: 8px;
 }
 
 .size-picker {
@@ -189,15 +260,15 @@ body {
   font-size: 15px;
   font-weight: 800;
   color: #ffffff;
-  background: linear-gradient(135deg, #fb923c, #f97316);
-  box-shadow: 0 12px 24px rgba(249, 115, 22, 0.22);
+  background: linear-gradient(135deg, #6366f1, #7c3aed);
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.24);
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
 .primary-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 32px rgba(249, 115, 22, 0.28);
+  box-shadow: 0 16px 32px rgba(99, 102, 241, 0.32);
 }
 
 .primary-button:disabled {
@@ -209,6 +280,41 @@ body {
   color: #94a3b8;
 }
 
+.primary-button--ghost {
+  background: #ffffff;
+  color: #0f172a;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: capitalize;
+  border: 1px solid var(--border);
+  background: #ffffff;
+  color: #334155;
+  box-shadow: 0 8px 18px rgba(148, 163, 184, 0.18);
+}
+
+.pill--ghost {
+  background: rgba(255, 255, 255, 0.6);
+  color: #475569;
+}
+
+.pill--glow {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(236, 72, 153, 0.12));
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  color: #5b21b6;
+  box-shadow: 0 12px 32px rgba(99, 102, 241, 0.18);
+}
+
 .app__body {
   flex: 1;
   width: 100%;
@@ -218,6 +324,102 @@ body {
   display: grid;
   gap: 24px;
   grid-template-columns: 1fr;
+  position: relative;
+  z-index: 1;
+}
+
+.hero {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero__left {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.hero__title {
+  margin: 0;
+  font-size: clamp(26px, 4vw, 34px);
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: #475569;
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.hero__right {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metric-tile {
+  background: linear-gradient(135deg, #eef2ff, #e0f2fe);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.12);
+}
+
+.metric-tile__label {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.metric-tile__value {
+  margin: 4px 0 2px;
+  font-size: 28px;
+  font-weight: 800;
+}
+
+.metric-tile__hint {
+  margin: 0;
+  color: #475569;
+  font-size: 13px;
+}
+
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.metric-card {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+}
+
+.metric-card__value {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.metric-card__label {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-weight: 600;
 }
 
 .sidebar {
@@ -227,12 +429,23 @@ body {
   overflow-y: auto;
 }
 
+.sidebar .card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.75));
+  backdrop-filter: blur(6px);
+}
+
 .card {
   background: #ffffff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
   border-radius: 18px;
   padding: 20px;
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.05);
+}
+
+.card--gradient {
+  background: linear-gradient(145deg, var(--gradient-start), var(--gradient-end));
+  box-shadow: var(--card-glow);
+  border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 .card__header {
@@ -346,6 +559,7 @@ body {
   font-size: 14px;
   color: #0f172a;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .textarea-input {
@@ -403,11 +617,12 @@ body {
 
 .results-card {
   height: 100%;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid var(--border);
   border-radius: 22px;
   padding: 28px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 20px 36px rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(10px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), 0 24px 48px rgba(79, 70, 229, 0.08);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -467,6 +682,7 @@ body {
   flex: 1;
   overflow-x: auto;
   padding-bottom: 12px;
+  mask-image: linear-gradient(90deg, transparent, #000 20px, #000 calc(100% - 20px), transparent);
 }
 
 .results-list {
@@ -478,11 +694,11 @@ body {
 
 .slide-card {
   width: 360px;
-  background: #ffffff;
+  background: linear-gradient(135deg, #ffffff, #f8fafc);
   border-radius: 18px;
   padding: 20px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -494,7 +710,7 @@ body {
 }
 
 .slide-card--cta {
-  background: #eef2ff;
+  background: linear-gradient(135deg, #eef2ff, #e0f2fe);
   border-color: #c7d2fe;
 }
 
@@ -502,9 +718,10 @@ body {
   position: relative;
   border-radius: 12px;
   overflow: hidden;
-  background: #f1f5f9;
+  background: linear-gradient(135deg, #f8fafc, #eef2ff);
   border: 1px solid #f8fafc;
   aspect-ratio: 4 / 3;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 .slide-card__image {
@@ -565,7 +782,7 @@ body {
 .icon-button {
   border: none;
   background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
   padding: 10px;
   border-radius: 10px;
   cursor: pointer;
@@ -638,7 +855,7 @@ body {
 .slide-card__foot {
   margin-top: auto;
   padding-top: 12px;
-  border-top: 1px solid #f1f5f9;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .slide-card__foot-label {

--- a/App.tsx
+++ b/App.tsx
@@ -19,6 +19,10 @@ const App: React.FC = () => {
   const [isCreatingStoryboard, setIsCreatingStoryboard] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const activeResults = mode === 'slideshow' ? slideshowResults : manualResults;
+  const generatedCount = activeResults.filter((item) => item.imageUrl).length;
+  const totalScenes = activeResults.length;
+
   useEffect(() => {
     const checkKey = async () => {
       if (window.aistudio) {
@@ -192,6 +196,11 @@ const App: React.FC = () => {
 
   return (
     <div className="app">
+      <div className="app__background">
+        <span className="app__orb app__orb--left" />
+        <span className="app__orb app__orb--right" />
+      </div>
+
       <header className="app__header">
         <div className="app__header-content">
           <div className="brand">
@@ -200,7 +209,11 @@ const App: React.FC = () => {
                 <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2 1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
             </div>
-            <h1 className="brand__title">Consistency Studio</h1>
+            <div className="brand__text">
+              <p className="brand__eyebrow">Storyboard SaaS</p>
+              <h1 className="brand__title">Consistency Studio</h1>
+              <p className="brand__subtitle">Polished, Canva-grade visuals with locked-in characters.</p>
+            </div>
           </div>
 
           <div className="mode-toggle">
@@ -218,9 +231,14 @@ const App: React.FC = () => {
                 Manual Generation
               </button>
             </div>
+            <p className="mode-toggle__helper">Switch between AI storyboard or hands-on crafting.</p>
           </div>
 
           <div className="header-actions">
+            <div className="header-actions__meta">
+              <span className="pill pill--ghost">{references.length || '0'} references</span>
+              <span className="pill pill--ghost">{totalScenes || '0'} scenes</span>
+            </div>
             <div className="size-picker">
               <span>Res</span>
               <div className="size-picker__options">
@@ -244,6 +262,46 @@ const App: React.FC = () => {
       </header>
 
       <main className="app__body">
+        <section className="hero card card--gradient">
+          <div className="hero__left">
+            <div className="pill pill--glow">New • Brighter workspace</div>
+            <h2 className="hero__title">Design-grade layouts without the design gruntwork.</h2>
+            <p className="hero__subtitle">
+              Blend storyboard prompts, character references, and high-res rendering in one streamlined surface inspired by modern
+              creative tools.
+            </p>
+            <div className="hero__cta">
+              <button onClick={() => fileInputRef.current?.click()} className="primary-button primary-button--ghost">
+                Upload references
+              </button>
+              <button onClick={startGeneration} disabled={isGenerating || references.length === 0} className="primary-button">
+                {isGenerating ? 'Processing...' : 'Generate now'}
+              </button>
+            </div>
+          </div>
+          <div className="hero__right">
+            <div className="metric-tile">
+              <p className="metric-tile__label">Identity lock</p>
+              <p className="metric-tile__value">{references.length > 0 ? 'Ready' : 'Pending'}</p>
+              <p className="metric-tile__hint">{references.length > 0 ? 'Consistency secured' : 'Add 1-3 portraits'}</p>
+            </div>
+            <div className="metric-row">
+              <div className="metric-card">
+                <p className="metric-card__value">{generatedCount}</p>
+                <p className="metric-card__label">Rendered scenes</p>
+              </div>
+              <div className="metric-card">
+                <p className="metric-card__value">{size}</p>
+                <p className="metric-card__label">Resolution</p>
+              </div>
+              <div className="metric-card">
+                <p className="metric-card__value">{mode === 'slideshow' ? 'Auto' : 'Manual'}</p>
+                <p className="metric-card__label">Mode</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <div className="sidebar custom-scrollbar">
           <section className="card">
             <div className="card__header">


### PR DESCRIPTION
## Summary
- add SaaS-like hero header with CTA, pill counters, and inline metrics
- introduce gradient/glass styling tokens and refreshed cards, toggles, and results layout
- surface counts for references/scenes and highlight render progress for a Canva-like feel

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695042e9730c8324994cb6c8f1444313)