### PR TITLE
fix: tidy auth modal layout sizing

### DIFF
--- a/pages/LandingPage.scss
+++ b/pages/LandingPage.scss
@@ -776,9 +776,10 @@
     position: relative;
     max-width: 640px;
     width: 100%;
-    height: 640px;
+    max-height: 90vh;
+    height: auto;
     border-radius: 18px;
-    overflow: hidden;
+    overflow: auto;
 
     &-backdrop {
       position: fixed;
@@ -808,8 +809,9 @@
 
     .auth-shell {
       min-height: unset;
-      height: 100%;
-      padding: 0;
+      height: auto;
+      padding: 24px;
+      background: transparent;
     }
   }
 


### PR DESCRIPTION
### Motivation
- The sign up / sign in modal layout was breaking when shown on the landing page and on smaller viewports. 
- The modal needed to adapt to viewport height and allow scrolling when content exceeds available space. 
- The inner auth shell was forcing full height and lacked appropriate padding and background when embedded in the modal.

### Description
- Update `pages/LandingPage.scss` to replace the fixed modal height with `max-height: 90vh`, `height: auto`, and `overflow: auto` to enable responsive sizing and scrolling. 
- Adjust the embedded `.auth-shell` to use `height: auto`, add `padding: 24px`, and set `background: transparent` for proper spacing and visuals inside the modal. 
- These are purely CSS/layout changes to improve the modal presentation without altering functionality.

### Testing
- Started the dev server with `npm run dev` and Next compiled successfully. 
- Executed a Playwright script that opened the landing page, triggered the auth modal, and captured a screenshot at `artifacts/auth-modal.png`, which completed successfully. 
- No unit tests were changed or required for this visual fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e75f32dbc8324a0096d8c36149921)