### PR TITLE
feat: add 'Forgot password' button and Supabase reset flow

### DIFF
--- a/components/AuthShell/AuthShell.tsx
+++ b/components/AuthShell/AuthShell.tsx
@@ -9,10 +9,12 @@ interface AuthShellProps {
   authError: string | null;
   authStatus: AuthStatus;
   isLoading: boolean;
+  isResettingPassword: boolean;
   isSignUpMode: boolean;
   onEmailChange: (value: string) => void;
   onPasswordChange: (value: string) => void;
   onToggleAuthMode: () => void;
+  onRequestPasswordReset: () => void;
   onSignIn: (event: React.FormEvent<HTMLFormElement>) => void;
   onSignUp: (event: React.FormEvent<HTMLFormElement>) => void;
 }
@@ -24,10 +26,12 @@ const AuthShell: React.FC<AuthShellProps> = ({
   authError,
   authStatus,
   isLoading,
+  isResettingPassword,
   isSignUpMode,
   onEmailChange,
   onPasswordChange,
   onToggleAuthMode,
+  onRequestPasswordReset,
   onSignIn,
   onSignUp,
 }) => {
@@ -103,6 +107,26 @@ const AuthShell: React.FC<AuthShellProps> = ({
             autoComplete={isSignUpMode ? "new-password" : "current-password"}
             minLength={6}
           />
+          {!isSignUpMode && (
+            <div style={{ textAlign: "right" }}>
+              <button
+                type="button"
+                onClick={onRequestPasswordReset}
+                disabled={isResettingPassword}
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: "inherit",
+                  textDecoration: "underline",
+                  cursor: "pointer",
+                  padding: 0,
+                  font: "inherit",
+                }}
+              >
+                {isResettingPassword ? "Sending reset email..." : "Forgot password?"}
+              </button>
+            </div>
+          )}
           <button
             type="submit"
             className="primary-button"

--- a/pages/AuthPage.tsx
+++ b/pages/AuthPage.tsx
@@ -12,10 +12,12 @@ const AuthPage: React.FC = () => {
     authMessage,
     authError,
     isLoading,
+    isResettingPassword,
     isSignUpMode,
     setAuthEmail,
     setAuthPassword,
     toggleAuthMode,
+    requestPasswordReset,
     signIn,
     signUp,
   } = useAuth();
@@ -52,10 +54,12 @@ const AuthPage: React.FC = () => {
       authError={authError}
       authStatus={authStatus}
       isLoading={isLoading}
+      isResettingPassword={isResettingPassword}
       isSignUpMode={isSignUpMode}
       onEmailChange={setAuthEmail}
       onPasswordChange={setAuthPassword}
       onToggleAuthMode={toggleAuthMode}
+      onRequestPasswordReset={requestPasswordReset}
       onSignIn={signIn}
       onSignUp={signUp}
     />


### PR DESCRIPTION
### Motivation
- Allow users who forget their password to request a password reset from the auth UI.
- Use Supabase's password reset API so the reset email and flow are managed by the existing auth backend.

### Description
- Added `isResettingPassword` state and `requestPasswordReset` function to `providers/AuthProvider.tsx` which calls `supabase.auth.resetPasswordForEmail` and sets success/error messages.
- Added a `Forgot password?` action and loading state to the sign-in form in `components/AuthShell/AuthShell.tsx` and styled it inline to match existing controls.
- Wired the new props through `pages/AuthPage.tsx` so the page passes `requestPasswordReset` and `isResettingPassword` into the UI.

### Testing
- Started the dev server with `npm run dev` and Next compiled the app successfully.
- Ran a Playwright script that loaded `/auth` and captured a screenshot showing the new "Forgot password?" link, and the run completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6962846bcbcc8324be2cfdc499e5d55e)