### PR TITLE
feat: add mobile unsupported view

### DIFF
--- a/App.scss
+++ b/App.scss
@@ -40,6 +40,63 @@ body {
   color: #e2e8f0;
 }
 
+.app-shell {
+  min-height: 100vh;
+}
+
+.mobile-unsupported {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: #0a0f1c;
+  color: #e2e8f0;
+  padding: 24px;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  z-index: 999;
+
+  &__card {
+    max-width: 420px;
+    padding: 32px 28px;
+    border-radius: 20px;
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(12px);
+  }
+
+  &__eyebrow {
+    font-size: var(--fs-11);
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    margin: 0 0 12px;
+    color: #94a3b8;
+  }
+
+  &__title {
+    font-size: var(--fs-26);
+    margin: 0 0 12px;
+    color: #f8fafc;
+  }
+
+  &__copy {
+    margin: 0;
+    font-size: var(--fs-15);
+    color: #cbd5f5;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-shell {
+    display: none;
+  }
+
+  .mobile-unsupported {
+    display: flex;
+  }
+}
+
 .app {
   height: 100vh;
   display: flex;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,7 +10,20 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
       <SubscriptionProvider>
-        <Component {...pageProps} />
+        <div className="app-shell">
+          <Component {...pageProps} />
+        </div>
+        <div className="mobile-unsupported" role="alert">
+          <div className="mobile-unsupported__card">
+            <p className="mobile-unsupported__eyebrow">Not supported</p>
+            <h1 className="mobile-unsupported__title">
+              This app is optimized for desktop
+            </h1>
+            <p className="mobile-unsupported__copy">
+              Open StoryboardGen on a larger screen to continue.
+            </p>
+          </div>
+        </div>
         {process.env.NEXT_PUBLIC_GA_ID && (
           <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
         )}


### PR DESCRIPTION
### Motivation
- The app is desktop-first and needs a clear message when opened on small screens, so a dedicated mobile "Not supported" experience is required.

### Description
- Added a mobile-only overlay component in `pages/_app.tsx` (`.mobile-unsupported`) that shows a headline, explanatory copy, and uses `role="alert"` for accessibility.
- Wrapped the main application output in a `.app-shell` container so the UI can be hidden on small viewports while the overlay is shown.
- Added styles and a responsive rule in `App.scss` to hide `.app-shell` and display `.mobile-unsupported` under `@media (max-width: 768px)`, and styled the overlay to match the app theme.

### Testing
- Started the Next.js dev server with `npm run dev` and confirmed the app compiled and served successfully (Next.js reported Ready). (succeeded)
- Ran a Playwright script that opened the app with a mobile viewport (`width: 390, height: 844`) and captured a screenshot showing the mobile unsupported screen. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698318aa119c8324ab6666334e630190)