### PR TITLE
fix: disable generation when requested images exceed remaining credits

### DIFF
--- a/components/DashboardV2/DashboardLayout.tsx
+++ b/components/DashboardV2/DashboardLayout.tsx
@@ -30,6 +30,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   isGenerating,
   disableGenerate,
   generateDisabledTooltip,
+  generateErrorMessage,
   onGenerateAll,
   onRegenerateActive,
   transparentBackground,
@@ -119,6 +120,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
       <FooterBar
         disableGenerate={disableGenerate}
         generateDisabledTooltip={generateDisabledTooltip}
+        generateErrorMessage={generateErrorMessage}
         isGenerating={isGenerating}
         onGenerateAll={onGenerateAll}
         projectName={projectName}

--- a/components/DashboardV2/DashboardMain.tsx
+++ b/components/DashboardV2/DashboardMain.tsx
@@ -26,6 +26,7 @@ const DashboardMain: React.FC<DashboardMainProps> = ({ dashboard }) => {
     isGenerating,
     disableGenerate,
     generateDisabledTooltip,
+    generateErrorMessage,
     startGeneration,
     handleRegenerate,
     handleGenerateCaption,
@@ -92,6 +93,7 @@ const DashboardMain: React.FC<DashboardMainProps> = ({ dashboard }) => {
         isGenerating={isGenerating}
         disableGenerate={disableGenerate}
         generateDisabledTooltip={generateDisabledTooltip}
+        generateErrorMessage={generateErrorMessage}
         onGenerateAll={startGeneration}
         onRegenerateActive={() => handleRegenerate(activeSceneIndex)}
         rules={rules}

--- a/components/DashboardV2/FooterBar.module.scss
+++ b/components/DashboardV2/FooterBar.module.scss
@@ -81,6 +81,13 @@
   margin-right: auto;
 }
 
+
+.generateErrorMessage {
+  color: #ff7a7a;
+  font-size: var(--fs-13);
+  align-self: center;
+}
+
 .generateButtonWrap {
   display: inline-flex;
 }

--- a/components/DashboardV2/FooterBar.tsx
+++ b/components/DashboardV2/FooterBar.tsx
@@ -5,6 +5,7 @@ import styles from "./FooterBar.module.scss";
 export interface FooterBarProps {
   disableGenerate: boolean;
   generateDisabledTooltip?: string | null;
+  generateErrorMessage?: string | null;
   isGenerating: boolean;
   onGenerateAll: () => void;
   projectName: string;
@@ -15,6 +16,7 @@ export interface FooterBarProps {
 const FooterBar: React.FC<FooterBarProps> = ({
   disableGenerate,
   generateDisabledTooltip,
+  generateErrorMessage,
   isGenerating,
   onGenerateAll,
   projectName,
@@ -65,6 +67,9 @@ const FooterBar: React.FC<FooterBarProps> = ({
           </div>
         )}
       </div> */}
+      {generateErrorMessage && (
+        <span className={styles.generateErrorMessage}>{generateErrorMessage}</span>
+      )}
       <span
         className={styles.generateButtonWrap}
         title={

--- a/components/DashboardV2/dashboardLayout.types.ts
+++ b/components/DashboardV2/dashboardLayout.types.ts
@@ -33,6 +33,7 @@ export interface DashboardLayoutProps {
   isGenerating: boolean;
   disableGenerate: boolean;
   generateDisabledTooltip?: string | null;
+  generateErrorMessage?: string | null;
   onGenerateAll: () => void;
   onRegenerateActive: () => void;
   transparentBackground: boolean;

--- a/hooks/useDashboardManual.ts
+++ b/hooks/useDashboardManual.ts
@@ -241,15 +241,30 @@ export const useDashboardManual = ({
   const hasValidScenePrompts = scenes.some(
     (scene) => scene.title.trim() || scene.description.trim()
   );
+  const scenesToGenerateCount = manualPrompts
+    .split("\n")
+    .filter((prompt) => prompt.trim() !== "").length;
   const noCreditsRemaining = !!(usage && usage.remaining <= 0);
+  const hasInsufficientCredits =
+    !!usage && scenesToGenerateCount > usage.remaining;
   const disableGenerate =
     isGenerating ||
     referencesWithData.length === 0 ||
     !hasValidScenePrompts ||
+    hasInsufficientCredits ||
     noCreditsRemaining ||
     !!usageError;
   const generateDisabledTooltip = noCreditsRemaining
     ? "No credits remaining. Upgrade for more."
+    : hasInsufficientCredits
+    ? `Not enough credits. ${scenesToGenerateCount} image${
+        scenesToGenerateCount === 1 ? "" : "s"
+      } requested, ${usage?.remaining ?? 0} credit${
+        (usage?.remaining ?? 0) === 1 ? "" : "s"
+      } remaining.`
+    : null;
+  const generateErrorMessage = hasInsufficientCredits
+    ? generateDisabledTooltip
     : null;
 
   const stripePlanLinks = useMemo(() => {
@@ -444,6 +459,7 @@ export const useDashboardManual = ({
     projectId,
     disableGenerate,
     generateDisabledTooltip,
+    generateErrorMessage,
     isReferenceLibraryOpen,
     setIsReferenceLibraryOpen,
     isPaymentModalOpen,


### PR DESCRIPTION
### Motivation
- Prevent users from starting image generation when they request more images than their remaining monthly credits and provide immediate, clear feedback next to the action button.

### Description
- Compute the requested scene/image count from `manualPrompts` and detect when it exceeds `usage.remaining` in `useDashboardManual` (`scenesToGenerateCount`, `hasInsufficientCredits`, `generateErrorMessage`).
- Propagate the new `generateErrorMessage` through the dashboard components (`DashboardMain` → `DashboardLayout` → `FooterBar`) and add a left-of-button inline error display in `FooterBar`.
- Add a new `generateErrorMessage` prop to the layout types and style the inline message in `FooterBar.module.scss`.
- Files changed: `hooks/useDashboardManual.ts`, `components/DashboardV2/DashboardMain.tsx`, `components/DashboardV2/DashboardLayout.tsx`, `components/DashboardV2/dashboardLayout.types.ts`, `components/DashboardV2/FooterBar.tsx`, `components/DashboardV2/FooterBar.module.scss`.

### Testing
- Ran `npx tsc --noEmit` to validate types and it succeeded.
- Started the app with `npm run dev` and loaded the UI (server started and a page screenshot was produced), confirming the UI change renders.
- Attempted `npm run lint` but it could not complete non-interactively due to the Next.js ESLint setup prompt in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699879908b3c8324af86f0410f1f66d6)