### PR TITLE
fix: update Gemini text model fallback

### DIFF
--- a/services/constants.tsx
+++ b/services/constants.tsx
@@ -48,4 +48,4 @@ export const DEFAULT_CHARACTER_BACKGROUND_SCENE = `
 
 export const MODEL_NAME = "gemini-3-pro-image-preview";
 export const CAPTION_MODEL_NAME =
-  process.env.GEMINI_TEXT_MODEL || "gemini-2.5-flash-lite";
+  process.env.GEMINI_TEXT_MODEL || "gemini-3.5-flash-lite";


### PR DESCRIPTION
## Summary
- Replace the deprecated `gemini-2.5-flash-lite` default text model fallback with `gemini-3.5-flash-lite`.
- Keep `GEMINI_TEXT_MODEL` override behavior unchanged for deployments that explicitly set a model.

## Verification
- `npx tsc --noEmit` ✅
- `npm run build` compiled successfully, then was killed during static page generation with exit 137 in this container.

## Notes
- The repo's lockfile is currently out of sync with `package.json`, so `npm ci` fails before running checks. I used `npm install --legacy-peer-deps` locally for verification and reverted lockfile changes before committing.
